### PR TITLE
Move knockout dependency to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
   "bugs": {
     "url": "https://github.com/derekpeterson/knockout.mapping/issues"
   },
-  "dependencies": {
+  "peerDependencies": {
+    "knockout": "^3.1.0"
+  },
+  "devDependencies": {
     "knockout": "^3.1.0"
   }
 }


### PR DESCRIPTION
Fixes including duplicate copies of knockout when using browserify to bundle javascript.
